### PR TITLE
Improve dashboard playground handling

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,38 +1,45 @@
-import EmptyState from '@/components/ui/empty-state';
-import { deleteProjectById, duplicateProjectById, editProjectById, getAllPlaygroundForUser } from '@/features/dashboard/actions';
-import AddNewButton from '@/features/dashboard/components/add-new-button'
-import AddRepoButton from '@/features/dashboard/components/add-repo-button'
-import ProjectTable from '@/features/dashboard/components/project-table';
-import React from 'react'
+import EmptyState from "@/components/ui/empty-state";
+import {
+  deleteProjectById,
+  duplicateProjectById,
+  editProjectById,
+  getAllPlaygroundForUser,
+} from "@/features/dashboard/actions";
+import AddNewButton from "@/features/dashboard/components/add-new-button";
+import AddRepoButton from "@/features/dashboard/components/add-repo-button";
+import ProjectTable from "@/features/dashboard/components/project-table";
 
-const Page = async() => {
-    const playgrounds = await getAllPlaygroundForUser();
+const Page = async () => {
+  const playgrounds = await getAllPlaygroundForUser();
+  const hasProjects = playgrounds.length > 0;
+
   return (
-    <div className='flex flex-col justify-start items-center min-h-screen mx-auto max-w-7xl px-4 py-10'>
-        <div className='grid grid-cols-1 md:grid-cols-2 gap-6 w-full'>
-            <AddNewButton/>
-            <AddRepoButton/>
-        </div>
+    <div className="flex flex-col justify-start items-center min-h-screen mx-auto max-w-7xl px-4 py-10">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
+        <AddNewButton />
+        <AddRepoButton />
+      </div>
 
-        <div className='mt-10 flex flex-col justify-center items-center w-full'>
-       {
-        playgrounds && playgrounds.length === 0 ? (<EmptyState title='No projects Found'
-        description='Create a new project to get started' imageSrc='/empty-state.svg'/>) : (
-            // todo add playground table 
-           <ProjectTable
-          //  @ts-ignore
-          // TODO : NEED TO UPDATE TYPES OF THE PLAYGROUND
-           projects = {playgrounds || []}
-           onDeleteProject = {deleteProjectById}
-           onUpdateProject = {editProjectById}
-           onDuplicateProject = {duplicateProjectById}
-           />
-        )
-       }
-        </div>
-
+      <div className="mt-10 flex flex-col justify-center items-center w-full">
+        {hasProjects ? (
+          <ProjectTable
+            //  @ts-ignore
+            // TODO : NEED TO UPDATE TYPES OF THE PLAYGROUND
+            projects={playgrounds}
+            onDeleteProject={deleteProjectById}
+            onUpdateProject={editProjectById}
+            onDuplicateProject={duplicateProjectById}
+          />
+        ) : (
+          <EmptyState
+            title="No projects Found"
+            description="Create a new project to get started"
+            imageSrc="/empty-state.svg"
+          />
+        )}
+      </div>
     </div>
-  )
-}
+  );
+};
 
-export default Page
+export default Page;

--- a/features/dashboard/actions/index.ts
+++ b/features/dashboard/actions/index.ts
@@ -11,107 +11,111 @@ export const createPlayground = async (data: {
 }) => {
   const { template, title, description } = data;
   const user = await currentUser();
+
+  if (!user?.id) {
+    console.error("Attempted to create a playground without an authenticated user.");
+    return null;
+  }
+
   try {
     const playground = await db.playground.create({
-        data:{
-            title,
-            description,
-            template,
-            userId:user?.id!
-        }
+      data: {
+        title,
+        description,
+        template,
+        userId: user.id,
+      },
     });
+
     return playground;
   } catch (error) {
-    console.error(error)
+    console.error("Failed to create playground", error);
     return null;
   }
 };
 
-export const getAllPlaygroundForUser = async()=>{
-    const user = await currentUser();
-    try{
-        const playground = await db.playground.findMany({
-            where:{
-                userId:user?.id
-            },
-            include:{
-                user:true,
-                Starmark:{
-                    where:{
-                        userId:user?.id
-                    },
-                    select:{
-                        isMarked:true
-                    }
-                }
-            }
-        })
-        return playground
-    }
-    catch(error){
-        console.error(error)
-        return null;
-    }
-}
+export const getAllPlaygroundForUser = async () => {
+  const user = await currentUser();
 
-export const deleteProjectById = async (id:string)=>{
-    try {
-        await db.playground.delete({
-            where:{id}
-        })
-        revalidatePath("/dashboard")
-    } catch (error) {
-        console.log(error)
-    }
-}
+  if (!user?.id) {
+    return [];
+  }
 
-export const editProjectById = async (id:string,data:{title:string , description:string})=>{
-    try {
-        await db.playground.update({
-            where:{id},
-            data:data
-        })
-        revalidatePath("/dashboard")
-    } catch (error) {
-        console.log(error)
-    }
-}
+  try {
+    const playground = await db.playground.findMany({
+      where: {
+        userId: user.id,
+      },
+      include: {
+        user: true,
+        Starmark: {
+          where: {
+            userId: user.id,
+          },
+          select: {
+            isMarked: true,
+          },
+        },
+      },
+    });
+
+    return playground;
+  } catch (error) {
+    console.error("Failed to fetch playgrounds for user", error);
+    return [];
+  }
+};
+
+export const deleteProjectById = async (id: string) => {
+  try {
+    await db.playground.delete({
+      where: { id },
+    });
+    revalidatePath("/dashboard");
+  } catch (error) {
+    console.error("Failed to delete project", error);
+  }
+};
+
+export const editProjectById = async (
+  id: string,
+  data: { title: string; description: string }
+) => {
+  try {
+    await db.playground.update({
+      where: { id },
+      data,
+    });
+    revalidatePath("/dashboard");
+  } catch (error) {
+    console.error("Failed to update project", error);
+  }
+};
 
 export const duplicateProjectById = async (id: string) => {
-    try {
-        // Fetch the original playground data
-        const originalPlayground = await db.playground.findUnique({
-            where: { id },
-            include: {
-                // templateFiles: true, // Include related template files
-            },
-        });
+  try {
+    const originalPlayground = await db.playground.findUnique({
+      where: { id },
+    });
 
-        if (!originalPlayground) {
-            throw new Error("Original playground not found");
-        }
-
-        // Create a new playground with the same data but a new ID
-        const duplicatedPlayground = await db.playground.create({
-            data: {
-                title: `${originalPlayground.title} (Copy)`,
-                description: originalPlayground.description,
-                template: originalPlayground.template,
-                userId: originalPlayground.userId,
-                // templateFiles: {
-                //   // @ts-ignore
-                //     create: originalPlayground.templateFiles.map((file) => ({
-                //         content: file.content,
-                //     })),
-                // },
-            },
-        });
-
-        // Revalidate the dashboard path to reflect the changes
-        revalidatePath("/dashboard");
-
-        return duplicatedPlayground;
-    } catch (error) {
-        console.error("Error duplicating project:", error);
+    if (!originalPlayground) {
+      throw new Error("Original playground not found");
     }
-}
+
+    const duplicatedPlayground = await db.playground.create({
+      data: {
+        title: `${originalPlayground.title} (Copy)`,
+        description: originalPlayground.description,
+        template: originalPlayground.template,
+        userId: originalPlayground.userId,
+      },
+    });
+
+    revalidatePath("/dashboard");
+
+    return duplicatedPlayground;
+  } catch (error) {
+    console.error("Error duplicating project", error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- ensure dashboard server actions validate the authenticated user before writing data
- guard the dashboard data fetch to avoid unauthenticated lookups and surface clearer logging
- simplify the dashboard page rendering logic to rely on empty arrays and cleaned JSX structure

## Testing
- `npm run lint` *(fails: existing repository lint issues in generated Prisma files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce480ffab4832b9a988ca57123ad20